### PR TITLE
add new dependencies for react v15.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "homepage": "https://github.com/derrickpelletier/react-loading-overlay#readme",
   "dependencies": {
+    "prop-types": "^15.5.10",
     "styled-components": "^1.0.8"
   },
   "devDependencies": {
@@ -49,6 +50,7 @@
     "enzyme": "^2.6.0",
     "jest": "^17.0.0",
     "react-addons-test-utils": "^15.3.2",
+    "react-test-renderer": "^15.5.4",
     "rimraf": "^2.5.4",
     "standard": "^8.4.0",
     "webpack": "^1.13.2"

--- a/src/LoadingOverlay.js
+++ b/src/LoadingOverlay.js
@@ -6,6 +6,7 @@
  */
 
 import React, { Children } from 'react'
+import PropTypes from 'prop-types'
 import ReactCSSTransitionGroup from 'react/lib/ReactCSSTransitionGroup'
 import styled, { keyframes } from 'styled-components'
 
@@ -65,15 +66,15 @@ class LoadingOverlayWrapper extends React.Component {
 }
 
 LoadingOverlayWrapper.propTypes = {
-  active: React.PropTypes.bool,
-  text: React.PropTypes.string,
-  spinner: React.PropTypes.bool,
-  spinnerSize: React.PropTypes.string,
-  className: React.PropTypes.string,
-  background: React.PropTypes.string,
-  color: React.PropTypes.string,
-  zIndex: React.PropTypes.number,
-  animate: React.PropTypes.bool
+  active: PropTypes.bool,
+  text: PropTypes.string,
+  spinner: PropTypes.bool,
+  spinnerSize: PropTypes.string,
+  className: PropTypes.string,
+  background: PropTypes.string,
+  color: PropTypes.string,
+  zIndex: PropTypes.number,
+  animate: PropTypes.bool
 }
 
 LoadingOverlayWrapper.defaultProps = {


### PR DESCRIPTION
Per this blog post: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html
- `prop-types` npm package replaces deprecated React.Proptypes
- `react-dom/test-utils` replaces deprecated `react-addons-test-utils`. Enzyme was using the deprecated package, and now requires `react-test-renderer` as a dev dependency when using React >=15.5