### PR TITLE
improve click reliability 

### DIFF
--- a/src/LoadingOverlay.js
+++ b/src/LoadingOverlay.js
@@ -89,103 +89,103 @@ LoadingOverlayWrapper.defaultProps = {
   style: {}
 }
 
+const Overlay = styled.div`
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  top: 0px;
+  left: 0px;
+  background: ${props => props.background};
+  color: ${props => props.color};
+  transition: opacity ${props => props.speed}ms ease-out;
+  display: flex;
+  text-align: center;
+  font-size: 1.2em;
+  z-index: ${props => props.zIndex};
+  &._loading-overlay-transition-appear,
+  &._loading-overlay-transition-enter {
+    opacity: 0.01;
+  }
+  &._loading-overlay-transition-appear._loading-overlay-transition-appear-active,
+  &._loading-overlay-transition-enter._loading-overlay-transition-enter-active {
+    opacity: 1;
+    transition: opacity .5s ease-in;
+  }
+  &._loading-overlay-transition-leave {
+    opacity: 1;
+  }
+  &._loading-overlay-transition-leave._loading-overlay-transition-leave-active {
+    opacity: 0;
+    transition: opacity .5s ease-in;
+  }
+`
+
+const Spinner = styled.div`
+  position: relative;
+  margin: 0px auto 10px auto;
+  width: ${props => props.spinnerSize};
+  max-height: 100%;
+  &:before {
+    content: '';
+    display: block;
+    padding-top: 100%;
+  }
+`
+
+const Content = styled.div`
+  margin: auto;
+`
+
+const rotate360 = keyframes`
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+`
+
+const spinnerDash = keyframes`
+  0% {
+    stroke-dasharray: 1,200;
+    stroke-dashoffset: 0;
+  }
+  50% {
+    stroke-dasharray: 89,200;
+    stroke-dashoffset: -35px;
+  }
+  100% {
+    stroke-dasharray: 89,200;
+    stroke-dashoffset: -124px;
+  }
+`
+
+const Svg = styled.svg`
+  animation: ${rotate360} 2s linear infinite;
+  height: 100%;
+  transform-origin: center center;
+  width: 100%;
+  position: absolute;
+  top: 0; bottom: 0; left: 0; right: 0;
+  margin: auto;
+`
+
+const Circle = styled.circle`
+  animation: ${spinnerDash} 1.5s ease-in-out infinite;
+  stroke-dasharray: 1,200;
+  stroke-dashoffset: 0;
+  stroke-linecap: round;
+  stroke: ${props => props.color};
+`
+
 class LoadingOverlay extends React.Component {
   render () {
-    const Overlay = styled.div`
-      position: absolute;
-      height: 100%;
-      width: 100%;
-      top: 0px;
-      left: 0px;
-      background: ${this.props.background};
-      color: ${this.props.color};
-      transition: opacity ${this.props.speed}ms ease-out;
-      display: flex;
-      text-align: center;
-      font-size: 1.2em;
-      z-index: ${this.props.zIndex};
-      &._loading-overlay-transition-appear,
-      &._loading-overlay-transition-enter {
-        opacity: 0.01;
-      }
-      &._loading-overlay-transition-appear._loading-overlay-transition-appear-active,
-      &._loading-overlay-transition-enter._loading-overlay-transition-enter-active {
-        opacity: 1;
-        transition: opacity .5s ease-in;
-      }
-      &._loading-overlay-transition-leave {
-        opacity: 1;
-      }
-      &._loading-overlay-transition-leave._loading-overlay-transition-leave-active {
-        opacity: 0;
-        transition: opacity .5s ease-in;
-      }
-    `
-
-    const Spinner = styled.div`
-      position: relative;
-      margin: 0px auto 10px auto;
-      width: ${this.props.spinnerSize};
-      max-height: 100%;
-      &:before {
-        content: '';
-        display: block;
-        padding-top: 100%;
-      }
-    `
-
-    const Content = styled.div`
-      margin: auto;
-    `
-
-    const rotate360 = keyframes`
-      from {
-        transform: rotate(0deg);
-      }
-      to {
-        transform: rotate(360deg);
-      }
-    `
-
-    const spinnerDash = keyframes`
-      0% {
-        stroke-dasharray: 1,200;
-        stroke-dashoffset: 0;
-      }
-      50% {
-        stroke-dasharray: 89,200;
-        stroke-dashoffset: -35px;
-      }
-      100% {
-        stroke-dasharray: 89,200;
-        stroke-dashoffset: -124px;
-      }
-    `
-
-    const Svg = styled.svg`
-      animation: ${rotate360} 2s linear infinite;
-      height: 100%;
-      transform-origin: center center;
-      width: 100%;
-      position: absolute;
-      top: 0; bottom: 0; left: 0; right: 0;
-      margin: auto;
-    `
-
-    const Circle = styled.circle`
-      animation: ${spinnerDash} 1.5s ease-in-out infinite;
-      stroke-dasharray: 1,200;
-      stroke-dashoffset: 0;
-      stroke-linecap: round;
-      stroke: ${this.props.color};
-    `
-
     let spinnerNode = null
     if (this.props.spinner) {
       spinnerNode = (
-        <Spinner>
+        <Spinner spinnerSize={this.props.spinnerSize}>
           <Svg viewBox='25 25 50 50'>
-            <Circle cx='50' cy='50' r='20' fill='none' strokeWidth='2' strokeMiterlimit='10' />
+            <Circle color={this.props.color} cx='50' cy='50' r='20' fill='none' strokeWidth='2' strokeMiterlimit='10' />
           </Svg>
         </Spinner>
       )
@@ -204,7 +204,17 @@ class LoadingOverlay extends React.Component {
       )
     }
 
-    return <Overlay key='dimmer' onClick={this.props.onClick}>{contentNode}</Overlay>
+    return (
+      <Overlay
+        background={this.props.background}
+        color={this.props.color}
+        speed={this.props.speed}
+        zIndex={this.props.zIndex}
+        key='dimmer'
+        onClick={this.props.onClick}>
+        {contentNode}
+      </Overlay>
+    )
   }
 }
 


### PR DESCRIPTION
Noticed that clicking an overlay which were re-rendering frequently caused very few hits to actually register. Seemingly due to new css styles being injected for each render. Moving the styled components out of render fixes this. 