### PR TITLE
Moved styled components to peer and dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
   "homepage": "https://github.com/derrickpelletier/react-loading-overlay#readme",
   "dependencies": {
     "prop-types": "^15.5.10",
-    "react-transition-group": "^1.2.1",
-    "styled-components": "^2.1.2"
+    "react-transition-group": "^1.2.1"
   },
   "devDependencies": {
     "@kadira/storybook": "2.6.0",
@@ -56,10 +55,12 @@
     "react-test-renderer": "^15.5.4",
     "rimraf": "^2.5.4",
     "standard": "^8.4.0",
-    "webpack": "^1.13.2"
+    "webpack": "^1.13.2",
+    "styled-components": "latest"
   },
   "peerDependencies": {
     "react": "^0.14 || ^15.0.0-rc || ^15.0 || ^16.0.0 || ^16.0",
-    "react-dom": "^0.14 || ^15.0.0-rc || ^15.0 || ^16.0.0 || ^16.0"
+    "react-dom": "^0.14 || ^15.0.0-rc || ^15.0 || ^16.0.0 || ^16.0",
+    "styled-components": "*"
   }
 }


### PR DESCRIPTION
To avoid [this issue](https://github.com/styled-components/styled-components/issues/1305) I moved `styled-components` into `devDependencies` and `peerDependencies`