### PR TITLE
add position props support

### DIFF
--- a/.storybook/stories/LoadingOverlay.js
+++ b/.storybook/stories/LoadingOverlay.js
@@ -125,3 +125,13 @@ storiesOf('LoadingOverlay', module)
       {wrapped}
     </LoadingOverlay>
   ))
+  .add("position fixed", () => (
+    <LoadingOverlay
+      active
+      spinner
+      position='fixed'
+      text='Both spinner and text will remain in the center'
+      >
+      {wrapped}
+    </LoadingOverlay>
+  ))

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A customizable, simple loading overlay with transitions.
 Wrap your components in it and toggle the `active` prop as necessary.
 
 ```javascript
-import LoadingOverlay from 'react-loading-overlay';
+import LoadingOverlay from '@tkforce/react-loading-overlay';
 
 <LoadingOverlay
   active={isActive}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-loading-overlay",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tkforce/react-loading-overlay",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Loading overlays with fade, spinner, message support. Originate from https://github.com/derrickpelletier/react-loading-overlay",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "react-loading-overlay",
+  "name": "@tkforce/react-loading-overlay",
   "version": "0.3.0",
-  "description": "Loading overlays with fade, spinner, message support.",
+  "description": "Loading overlays with fade, spinner, message support. Originate from https://github.com/derrickpelletier/react-loading-overlay",
   "keywords": [
     "react",
     "loading",
@@ -24,17 +24,17 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/derrickpelletier/react-loading-overlay.git"
+    "url": "git+https://github.com/tkforce/react-loading-overlay"
   },
   "author": {
-    "name": "Derrick Pelletier",
-    "email": "derrick@dpelletier.com",
-    "url": "http://dpelletier.com"
+    "name": "tkforce",
+    "email": "chihweilin.derek@gmail.com",
+    "url": "https://tkforce.github.io/CV/"
   },
   "bugs": {
     "url": "https://github.com/derrickpelletier/react-loading-overlay/issues"
   },
-  "homepage": "https://github.com/derrickpelletier/react-loading-overlay#readme",
+  "homepage": "https://github.com/tkforce/react-loading-overlay#readme",
   "dependencies": {
     "prop-types": "^15.5.10",
     "react-transition-group": "^1.2.1",

--- a/src/LoadingOverlay.js
+++ b/src/LoadingOverlay.js
@@ -72,6 +72,7 @@ LoadingOverlayWrapper.propTypes = {
   spinnerSize: PropTypes.string,
   className: PropTypes.string,
   background: PropTypes.string,
+  position: PropTypes.string,
   color: PropTypes.string,
   zIndex: PropTypes.number,
   animate: PropTypes.bool,
@@ -82,6 +83,7 @@ LoadingOverlayWrapper.defaultProps = {
   active: false,
   className: '_loading-overlay',
   background: 'rgba(0, 0, 0, 0.7)',
+  position: 'absolute',
   spinnerSize: '50px',
   color: '#FFF',
   zIndex: 800,
@@ -90,7 +92,7 @@ LoadingOverlayWrapper.defaultProps = {
 }
 
 const Overlay = styled.div`
-  position: absolute;
+  position: ${props => props.position};
   height: 100%;
   width: 100%;
   top: 0px;
@@ -208,6 +210,7 @@ class LoadingOverlay extends React.Component {
       <Overlay
         background={this.props.background}
         color={this.props.color}
+        position={this.props.position}
         speed={this.props.speed}
         zIndex={this.props.zIndex}
         key='dimmer'


### PR DESCRIPTION
I was using this awesome loading overlay as a global overlay for our SPA  project, but with the position:absolute property, the loading spinner and the text will be centered in the scope of entire page rather than the viewing window. I'd suggest we add a position property to the props so that user can adjust accordingly, Thanks! 