### PR TITLE
Fix IE11 Spinner Positioning

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -45,7 +45,8 @@ export default {
     opacity: (state === 'entering' || state === 'entered') ? 1 : 0
   }),
   content: () => ({
-    margin: 'auto'
+    margin: 'auto',
+    display: 'flex'
   }),
   spinner: (state) => ({
     position: 'relative',


### PR DESCRIPTION
Fixes issue #35 

IE11 requires the `display: flex` CSS rule on the content div.